### PR TITLE
Added the ability to change the shell of the user prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Available variables are listed below, along with default values:
 ```yaml
 prometheus_exporters_common_user:   prometheus
 prometheus_exporters_common_group:  prometheus
+prometheus_exporters_common_shell: "/sbin/nologin"
 
 prometheus_exporters_common_root_dir: /opt/prometheus/exporters
 prometheus_exporters_common_dist_dir: "{{ prometheus_exporters_common_root_dir }}/dist"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 
 prometheus_exporters_common_user: prometheus
 prometheus_exporters_common_group: prometheus
+prometheus_exporters_common_shell: "/sbin/nologin"
 
 prometheus_exporters_common_root_dir: /opt/prometheus/exporters
 prometheus_exporters_common_dist_dir: "{{ prometheus_exporters_common_root_dir }}/dist"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
   user:
     name: "{{ prometheus_exporters_common_user }}"
     system: yes
-    shell: "/sbin/nologin"
+    shell: "{{ prometheus_exporters_common_shell }}"
     group: "{{ prometheus_exporters_common_group }}"
     createhome: no
 


### PR DESCRIPTION
Would like to be able to modify the shell path has it conflict with some legacy installation which uses a different path : /usr/sbin/nologin