### PR TITLE
Avoid failures in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
     owner: "{{ prometheus_exporters_common_user }}"
     group: "{{ prometheus_exporters_common_group }}"
     mode: 0755
+    check_mode: no
   with_items:
     - "{{ prometheus_exporters_common_root_dir }}"
     - "{{ prometheus_exporters_common_dist_dir }}"


### PR DESCRIPTION
Add `check_mode: no` for task "create prometheus directories" in order to avoid failures with role prometheus-node-exporter when run with check mode.